### PR TITLE
Removes `HTTP_PROXY` header, it's a security risk

### DIFF
--- a/templates/vhost/fastcgi_params.erb
+++ b/templates/vhost/fastcgi_params.erb
@@ -25,3 +25,6 @@ fastcgi_param  HTTPS              $https;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Removing HTTP_PROXY as per https://httpoxy.org/#mitigate-nginx
+fastcgi_param  HTTP_PROXY         "";


### PR DESCRIPTION
Please read https://httpoxy.org/ for more details.

Basically if someone sends a `Proxy` header to a CGI application, CGI, by _design_ asks that headers are merged into `$_SERVER` and `getenv` which means Guzzle etc. are vulnerable to being redirected to a user-defined proxy. Niiiice.

Implements: https://httpoxy.org/#mitigate-nginx

@nickcv-ln @inespons @artberri 
